### PR TITLE
Remove dependency on build for frontend deploy

### DIFF
--- a/incrowd/frontend/gulp/aws.js
+++ b/incrowd/frontend/gulp/aws.js
@@ -12,7 +12,7 @@ var aws = {
   "patternIndex": /(templateCacheHtml\.js)|(index\.html)/gi
 };
 
-gulp.task('prod', ['build'], function () {
+gulp.task('prod', function () {
 
   // create a new publisher
   var publisher = awspublish.create(aws);
@@ -41,7 +41,7 @@ gulp.task('prod', ['build'], function () {
   //.pipe(cloudfront(aws));
 });
 
-gulp.task('preprod', ['build'], function () {
+gulp.task('preprod', function () {
 
   var publisher = awspublish.create({
     params: {


### PR DESCRIPTION
It is not that hard to run 'gulp build && gulp deploy', but
breaking it out means CI/CD can deploy the dist files from the
docker container.