### PR TITLE
Add base directory to gulp build

### DIFF
--- a/incrowd/frontend/gulp/build.js
+++ b/incrowd/frontend/gulp/build.js
@@ -76,7 +76,7 @@ gulp.task('partials', ['markups'], function () {
 gulp.task('html', ['inject'], function () {
 
   var assets;
-  return gulp.src(paths.tmp + '/serve/*.html')
+  return gulp.src(paths.tmp + '/serve/*.html', {base: paths.src})
     .pipe(assets = $.useref.assets())
     .pipe(assets.restore())
     .pipe(print(function (filepath) {


### PR DESCRIPTION
Not having the base was causing weird pathing issues.