### PR TITLE
Move js/css paths to gulpfile, fix injection

### DIFF
--- a/incrowd/frontend/gulp/build.js
+++ b/incrowd/frontend/gulp/build.js
@@ -17,35 +17,27 @@ var $ = require('gulp-load-plugins')({
 });
 
 gulp.task('inject', ['partials', 'styles', 'config', 'webkitFix'], function () {
-  var injectStyles = gulp.src([
-    paths.src + '/assets/css/incrowd-custom-theme.css',
-    paths.src + '/assets/css/*.css',
-    paths.src + '/components/**/*.css',
-    '!' + paths.tmp + '/serve/app/vendor.css'
-  ], {read: false});
-
-  var injectScripts = gulp.src([
-    paths.src + '/{app,components}/**/*.js',
-    '!' + paths.src + '/angular.js',
-    '!' + paths.src + '/settings.js',
-    '!' + paths.src + '/app/js/config.js',
-    '!' + paths.src + '/{app,components}/**/*.spec.js',
-    '!' + paths.src + '/{app,components}/**/*.mock.js'
-  ]).pipe($.angularFilesort());
-
-  var injectOptions = {
-    ignorePath: [paths.src],
-    addRootSlash: false
-  };
-
   var wiredepOptions = {
     directory: 'src/lib',
     exclude: [/bootstrap\.css/, /foundation\.css/, 'src/lib/angular/angular.js']
   };
 
+  // Sort scripts for angular before injecting
+  var injectScripts = gulp.src(paths.js).pipe($.angularFilesort());
+
   return gulp.src(paths.src + '/*.html')
-    .pipe($.inject(injectStyles, injectOptions))
-    .pipe($.inject(injectScripts, injectOptions))
+    .pipe($.inject(
+      gulp.src(paths.css, {read: false}), {
+        ignorePath: [paths.src],
+        addRootSlash: false,
+        name: 'styles'
+      }))
+    .pipe($.inject(injectScripts, {
+      ignorePath: [paths.src],
+      addRootSlash: false,
+      name: 'angular'
+    }))
+
     // Use relative here so it gets picked up a findable file in assets() in
     // 'html'.
     .pipe($.inject(gulp.src(paths.src + '/cache/templateCacheHtml.js',

--- a/incrowd/frontend/gulpfile.js
+++ b/incrowd/frontend/gulpfile.js
@@ -10,8 +10,24 @@ gulp.paths = {
   lib: 'src/lib'
 };
 
+gulp.paths.css = [
+  gulp.paths.src + '/assets/css/incrowd-custom-theme.css',
+  gulp.paths.src + '/assets/css/*.css',
+  gulp.paths.src + '/components/**/*.css',
+  '!' + gulp.paths.tmp + '/serve/app/vendor.css'
+];
+
+gulp.paths.js = [
+  gulp.paths.src + '/{app,components}/**/*.js',
+  '!' + gulp.paths.src + '/angular.js',
+  '!' + gulp.paths.src + '/settings.js',
+  '!' + gulp.paths.src + '/app/js/config.js',
+  '!' + gulp.paths.src + '/{app,components}/**/*.spec.js',
+  '!' + gulp.paths.src + '/{app,components}/**/*.mock.js'
+];
+
 require('require-dir')('./gulp');
 
 gulp.task('default', ['clean'], function () {
-    gulp.start('build');
+  gulp.start('build');
 });

--- a/incrowd/frontend/src/index.html
+++ b/incrowd/frontend/src/index.html
@@ -26,7 +26,7 @@
   <!-- build:css(src) assets/incrowd.css -->
   <!-- bower:css -->
   <!-- endbower -->
-  <!-- inject:css -->
+  <!-- styles:css -->
   <!-- endinject -->
   <!-- endbuild -->
 </head>
@@ -129,7 +129,7 @@
 <!-- endbuild -->
 
 <!-- build:js(src) scripts/app.js -->
-<!-- inject:js -->
+<!-- angular:js -->
 <!-- endinject -->
 <!-- config:js -->
 <!-- endinject -->


### PR DESCRIPTION
Injection wasn't working correctly all of the sudden. Using named
injections fixes the problem. Move the list of files the paths to
simplify resuability in the future.