### PR TITLE
Fix older posts not loading

### DIFF
--- a/incrowd/frontend/src/app/incrowd/post.js
+++ b/incrowd/frontend/src/app/incrowd/post.js
@@ -65,8 +65,21 @@ angular.module('incrowdLib')
     });
 
     Posts.get = function (id) {
+      var getDeferred = $q.defer();
+
       var index = getPostIndex(id);
-      return Posts.posts[index];
+      if (index === undefined) {
+        // Not in the cache, fetch post
+        // TODO: should cache this lookup.. but need to figure out how to display posts in order still
+        $log.debug('Post not in cache, fetching: ', id);
+        Posts.resource.get({postId: id}).$promise.success(function (post) {
+          getDeferred.resolve(post);
+        })
+      }
+      else {
+        getDeferred.resolve(Posts.posts[index]);
+      }
+      return getDeferred.promise;
     };
 
     Posts.delete = function (id) {

--- a/incrowd/frontend/src/app/incrowd/utils.js
+++ b/incrowd/frontend/src/app/incrowd/utils.js
@@ -11,11 +11,11 @@ angular.module('incrowdLib')
       var difference = (now - Date.parse(dt)) / 1000;
       if (difference < 60) {
         time = Math.floor(difference);
-        return "just now";
+        return 'just now';
       }
       if (difference < 3600) {
         time = Math.floor(difference / 60);
-        label = time > 1;
+        label = 's';
       }
       else if (difference < 86400) {
         time = Math.floor(difference / 3600);

--- a/incrowd/frontend/src/components/post/post.js
+++ b/incrowd/frontend/src/components/post/post.js
@@ -77,10 +77,11 @@ angular.module('incrowd')
 
     // Bind to the post once fetched
     Posts.promise.then(function () {
-      $scope.post = Posts.get(parseInt($scope.postId));
+      Posts.get(parseInt($scope.postId)).then(function(post) {
+        $scope.post = post;
+      });
       //$scope.post.youtube = youtube_url_to_id($scope.post.url);
     });
-
 
     $scope.formData = new Posts.Comments.resource({post: $scope.postId});
     $scope.submitDhow = false;


### PR DESCRIPTION
When going to a post detail page that wasn't loaded as of normal
page load, the page would be blank. Need to fetch the page from
the backend if it isn't in the cache.

Also fixed an error in dtsince where 'X s' for seconds would show up
as 'X true'.